### PR TITLE
AppImage support

### DIFF
--- a/BattleNetwork/bnHitProperties.h
+++ b/BattleNetwork/bnHitProperties.h
@@ -2,6 +2,11 @@
 #include "bnElements.h"
 #include "bnDirection.h"
 
+#ifdef __GNUC__
+	#include <cstdint>
+#endif
+
+
 // forward declare
 using EntityID_t = long;
 

--- a/BattleNetwork/cxxopts/cxxopts.hpp
+++ b/BattleNetwork/cxxopts/cxxopts.hpp
@@ -39,6 +39,10 @@ THE SOFTWARE.
 #include <unordered_set>
 #include <vector>
 
+#ifdef __GNUC__
+	#include <cstdint>
+#endif
+
 #ifdef __cpp_lib_optional
 #include <optional>
 #define CXXOPTS_HAS_OPTIONAL

--- a/BattleNetwork/main.cpp
+++ b/BattleNetwork/main.cpp
@@ -26,6 +26,10 @@
 #include <Poco/URI.h>
 #include <Poco/StreamCopier.h>
 
+#ifdef APPIMAGE
+#include <filesystem>
+#endif
+
 // Launches the standard game with full setup and configuration
 int LaunchGame(Game& g, const cxxopts::ParseResult& results);
 
@@ -49,6 +53,30 @@ static cxxopts::Options options("ONB", "Open Net Battle Engine");
 
 int main(int argc, char** argv) {
   // Create help and other generic flags
+
+#ifdef APPIMAGE
+  // Change the working directory to the XDG_CONFIG_HOME path.
+  // This is a hack to get the program functioning in AppImage.
+  std::string USER_HOME = std::getenv("HOME");
+  std::string ONB_CONFIG_PATH = USER_HOME + "/.config/OpenNetBattle";
+  std::string ONB_RESOURCE_PATH = USER_HOME + "/.config/OpenNetBattle/resources";
+
+  std::cout << "This is an AppImage build. YMMV." << std::endl;
+
+  if(!std::filesystem::exists(ONB_CONFIG_PATH) || !std::filesystem::exists(ONB_RESOURCE_PATH)) {
+    std::filesystem::create_directory(ONB_CONFIG_PATH);
+    std::filesystem::create_directory(ONB_RESOURCE_PATH);
+    std::cout << "First run detected." << endl;
+    std::cout << endl;
+    std::cout << "Please extract the resource datafiles to " << ONB_RESOURCE_PATH << " and run the AppImage again." << endl;
+    return EXIT_FAILURE;
+  }
+
+  std::filesystem::current_path(ONB_CONFIG_PATH);
+
+#endif
+
+
   options.add_options()
     ("h,help", "Print all options")
     ("e,errorLevel", "Set the level to filter error messages [silent|info|warning|critical|debug] (default is `critical`)", cxxopts::value<std::string>()->default_value("warning|critical"))
@@ -87,7 +115,11 @@ int main(int argc, char** argv) {
     }
 
     DrawWindow win;
-    win.Initialize("Open Net Battle v2.0a", DrawWindow::WindowMode::window);
+  #ifdef APPIMAGE
+    win.Initialize("Open Net Battle v2.0a (AppImage Build)", DrawWindow::WindowMode::window);
+  #else
+   win.Initialize("Open Net Battle v2.0a", DrawWindow::WindowMode::window);
+  #endif
     Game game{ win };
 
     // Go the the title screen to kick off the rest of the app

--- a/BattleNetwork/overworld/bnIdentityManager.h
+++ b/BattleNetwork/overworld/bnIdentityManager.h
@@ -1,5 +1,9 @@
 #include <string>
 
+#ifdef __GNUC__
+	#include <cstdint>
+#endif
+
 namespace Overworld {
   /**
    * Identities should not be shared beyond a single server

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS        OFF)
 
 # Consider adding directive to detect for GNU/Linux specifically for these modifications
-# IF(GNU)
-set(CMAKE_CXX_FLAGS "-fpermissive -Wchanges-meaning")
-# ENDIF()
+IF(UNIX)
+	set(CMAKE_CXX_FLAGS "-fpermissive -Wchanges-meaning")
+ENDIF()
+
+IF(APPIMAGE)
+	add_compile_definitions(APPIMAGE)
+endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,11 @@ set(CMAKE_CXX_STANDARD          17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS        OFF)
 
+# Consider adding directive to detect for GNU/Linux specifically for these modifications
+# IF(GNU)
+set(CMAKE_CXX_FLAGS "-fpermissive -Wchanges-meaning")
+# ENDIF()
+
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
 include(FindLua)


### PR DESCRIPTION
Requires -DAPPIMAGE on build.
Pulled out the changes in ebea968fad0ec4ac5280e5a02f01bb511c08fc24, as they were made separately in ubuntu-fix.